### PR TITLE
Implemented Compact<u32> Scale encoding for larger than 4 bytes

### DIFF
--- a/scalecodec/types.py
+++ b/scalecodec/types.py
@@ -94,7 +94,12 @@ class CompactU32(Compact):
             self.data = ScaleBytes(bytearray(int((value << 2) | 0b10).to_bytes(4, 'little')))
 
         else:
-            raise NotImplemented('Value range not implemented')
+            for bytes_length in range(5, 68):
+                if 2 ** (8 * (bytes_length-1)) <= value < 2 ** (8 * bytes_length):
+                    self.data = ScaleBytes(bytearray(((bytes_length - 4) << 2 | 0b11).to_bytes(1, 'little') + value.to_bytes(bytes_length, 'little')))
+                    break
+            else:
+                raise ValueError('{} out of range'.format(value))
 
         return self.data
 

--- a/test/test_type_encoding.py
+++ b/test/test_type_encoding.py
@@ -47,6 +47,12 @@ class TestScaleTypeEncoding(unittest.TestCase):
         obj.encode(1000000)
         self.assertEqual(str(obj.data), "0x02093d00")
 
+    def test_compact_u32_larger_than_4bytes(self):
+
+        obj = CompactU32(ScaleBytes(bytearray()))
+        obj.encode(150000000000000)
+        self.assertEqual(str(obj.data), "0x0b0060b7986c88")
+
     def test_compact_u32_encode_decode(self):
 
         value = 2000001


### PR DESCRIPTION
Summary:
Because Compact<u32> Scale decoding already implemented for larger than
4 bytes decode. so also should
Implemented Compact<u32> Scale encoding for larger than 4 bytes

Test Plan:
python3 -m unittest test.test_type_encoding

Reviewers:

CC:

Maniphest Tasks: