### PR TITLE
ExtrinsicDecoder in default.json should be ExtrinsicsDecoder

### DIFF
--- a/scalecodec/type_registry/default.json
+++ b/scalecodec/type_registry/default.json
@@ -125,7 +125,7 @@
     },
     "EgressQueueRoot": "(ParaId, Hash)",
     "EventIndex": "u32",
-    "Extrinsic": "ExtrinsicDecoder",
+    "Extrinsic": "ExtrinsicsDecoder",
     "Gas": "u64",
     "IdentityFields": {
       "type": "set",


### PR DESCRIPTION
There is no ExtrinsicDecoder in the whole project, so I think maybe ExtrinsicsDecoder is the right one.