### PR TITLE
Add support for encoding/decoding mortal eras

### DIFF
--- a/scalecodec/utils/math.py
+++ b/scalecodec/utils/math.py
@@ -1,0 +1,43 @@
+# Python Scale Codec
+#
+# Copyright 2018-2020 openAware BV (NL).
+# This file is part of Polkascan.
+#
+# Polkascan is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Polkascan is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Polkascan. If not, see <http://www.gnu.org/licenses/>.
+#
+#  math.py
+
+"""Some simple math-related utility functions not present in the standard
+   library.
+"""
+
+from math import ceil, log2
+
+def trailing_zeros(value: int) -> int:
+    """Returns the number of trailing zeros in the binary representation of
+    the given integer.
+    """
+    num_zeros = 0
+    while value & 1 == 0:
+        num_zeros += 1
+        value >>= 1
+    return num_zeros
+
+def next_power_of_two(value: int) -> int:
+    """Returns the smallest power of two that is greater than or equal
+    to the given integer.
+    """
+    if value < 0:
+        raise ValueError("Negative integers not supported")
+    return 1 if value == 0 else 1 << ceil(log2(value))

--- a/test/test_scale_types.py
+++ b/test/test_scale_types.py
@@ -320,3 +320,21 @@ class TestScaleTypes(unittest.TestCase):
         self.assertEqual(value['call_args'][0]['value'], '0x0123456789')
         self.assertEqual(value['call_args'][0]['name'], '_remark')
 
+    def test_era_immortal(self):
+        obj = ScaleDecoder.get_decoder_class('Era', ScaleBytes('0x00'))
+        obj.decode()
+        self.assertEqual(obj.value, '00')
+    
+    def test_era_mortal(self):
+        obj = ScaleDecoder.get_decoder_class('Era', ScaleBytes('0x4e9c'))
+        obj.decode()
+        self.assertTupleEqual(obj.value, (32768, 20000))
+
+        obj = ScaleDecoder.get_decoder_class('Era', ScaleBytes('0xc503'))
+        obj.decode()
+        self.assertTupleEqual(obj.value, (64, 60))
+
+        obj = ScaleDecoder.get_decoder_class('Era', ScaleBytes('0x8502'))
+        obj.decode()
+        self.assertTupleEqual(obj.value, (64, 40))
+

--- a/test/test_type_encoding.py
+++ b/test/test_type_encoding.py
@@ -314,4 +314,35 @@ class TestScaleTypeEncoding(unittest.TestCase):
         self.assertRaises(TypeError, call.encode, '{"call_module": "Balances", "call_function": "transfer"}')
         self.assertRaises(TypeError, call.encode, 2)
 
+    def test_era_immortal_encode(self):
+        obj = ScaleDecoder.get_decoder_class('Era')
+        obj.encode('00')
+        self.assertEqual(str(obj.data), '0x00')
+    
+    def test_era_mortal_encode(self):
+        obj = ScaleDecoder.get_decoder_class('Era')
+        obj.encode((32768, 20000))
+        self.assertEqual(str(obj.data), '0x4e9c')
 
+        obj = ScaleDecoder.get_decoder_class('Era')
+        obj.encode((64, 60))
+        self.assertEqual(str(obj.data), '0xc503')
+
+        obj = ScaleDecoder.get_decoder_class('Era')
+        obj.encode((64, 40))
+        self.assertEqual(str(obj.data), '0x8502')
+
+    def test_era_mortal_encode_dict(self):
+        obj = ScaleDecoder.get_decoder_class('Era')
+        obj.encode({'period': 32768, 'phase': 20000})
+        self.assertEqual(str(obj.data), '0x4e9c')
+
+        obj = ScaleDecoder.get_decoder_class('Era')
+        obj.encode({'period': 32768, 'current': (32768 * 3) + 20000})
+        self.assertEqual(str(obj.data), '0x4e9c')
+
+        obj = ScaleDecoder.get_decoder_class('Era')
+        obj.encode({'period': 200, 'current': 1400})
+        obj2 = ScaleDecoder.get_decoder_class('Era')
+        obj2.encode((256, 120))
+        self.assertEqual(str(obj.data), str(obj2.data))


### PR DESCRIPTION
Mortal Eras are currently decoded to a tuple of `(period, phase)`. From what I could see, all of the other types are decoded to standard Python types with no custom classes, so I chose that representation to prevent the need for a custom class. This has a bit less functionality than the Rust and JavaScript versions, as those use custom types to represent Eras and allow things like calculating the birth and death of an era given a reference block number.

When encoding mortal eras, the input value can either be a tuple (period, phase), which is encoded directly, or a dict. If a dict is specified, it must contain the field 'period' as well as either the field 'phase' or 'current'.

If 'phase' is present, the period and phase are encoded directly, as if a tuple was given with those two values.

If 'current' is present, that is taken as the current block number, and the phase is calculated for the given period. In this case, the period will also be converted to the next power of two if it is not already a power of two. This is to simulate the behavior of the Rust crate's `Era::mortal` function which performs the above behavior.

Let me know if there are any changes you would like to see in this PR.