### PR TITLE
Remove length check to make as_multi_storage calls work

### DIFF
--- a/scalecodec/types.py
+++ b/scalecodec/types.py
@@ -757,7 +757,7 @@ class GenericAccountId(H256):
         super().__init__(data, **kwargs)
 
     def process_encode(self, value):
-        if value[0:2] != '0x' and len(value) == 47:
+        if value[0:2] != '0x':
             from scalecodec.utils.ss58 import ss58_decode
             self.ss58_address = value
             value = '0x{}'.format(ss58_decode(value))


### PR DESCRIPTION
This PR addresses the following traceback which was occurring on as_multi_storage calls:
```
Traceback (most recent call last):
  File "/Users/nathan/LocalCoinSwap/substrate-utils/substrateutils/helper.py", line 111, in as_multi_signature_payload
    as_multi.encode(
  File "/Users/nathan/.pyenv/versions/substrateutils/lib/python3.8/site-packages/scalecodec/base.py", line 320, in encode
    self.data = self.process_encode(value)
  File "/Users/nathan/.pyenv/versions/substrateutils/lib/python3.8/site-packages/scalecodec/types.py", line 1299, in process_encode
    data += arg_obj.encode(param_value)
  File "/Users/nathan/.pyenv/versions/substrateutils/lib/python3.8/site-packages/scalecodec/base.py", line 320, in encode
    self.data = self.process_encode(value)
  File "/Users/nathan/.pyenv/versions/substrateutils/lib/python3.8/site-packages/scalecodec/types.py", line 815, in process_encode
    data += element_obj.encode(element)
  File "/Users/nathan/.pyenv/versions/substrateutils/lib/python3.8/site-packages/scalecodec/base.py", line 320, in encode
    self.data = self.process_encode(value)
  File "/Users/nathan/.pyenv/versions/substrateutils/lib/python3.8/site-packages/scalecodec/types.py", line 765, in process_encode
    return super().process_encode(value)
  File "/Users/nathan/.pyenv/versions/substrateutils/lib/python3.8/site-packages/scalecodec/types.py", line 410, in process_encode
    raise ValueError('Value should start with "0x" and should be 32 bytes long')
ValueError: Value should start with "0x" and should be 32 bytes long
```