### PR TITLE
Add process_encode to OptionBytes

### DIFF
--- a/scalecodec/types.py
+++ b/scalecodec/types.py
@@ -192,6 +192,14 @@ class OptionBytes(ScaleType):
             return self.process_type('Bytes').value
 
         return None
+    
+    def process_encode(self, value):
+        
+        if value is not None:
+            sub_type_obj = Bytes()
+            return ScaleBytes('0x01') + sub_type_obj.encode(value)
+
+        return ScaleBytes('0x00')
 
 
 # TODO replace in metadata


### PR DESCRIPTION
To fix:

```text
File "..." in <module>
    call = substrate.compose_call(
File ".../site-packages/substrateinterface/base.py", line 1336, in compose_call
    call.encode({
File ".../site-packages/scalecodec/base.py", line 395, in encode
    self.data = self.process_encode(self.value)
File ".../site-packages/scalecodec/types.py", line 1343, in process_encode
    data += arg_obj.encode(param_value)
File ".../site-packages/scalecodec/base.py", line 395, in encode
    self.data = self.process_encode(self.value)
File ".../site-packages/scalecodec/base.py", line 399, in process_encode
    raise NotImplementedError("Encoding not implemented for this ScaleType")                                                                                               NotImplementedError: Encoding not implemented for this ScaleType
```