### PR TITLE
fix unapplied slashes definition

### DIFF
--- a/scalecodec/type_registry/default.json
+++ b/scalecodec/type_registry/default.json
@@ -2153,7 +2153,7 @@
         ],
         [
           "own",
-          "AccountId"
+          "Balance"
         ],
         [
           "others",


### PR DESCRIPTION
- fix type in UnappliedSlashes type in default.json

Reference to definition in the substrate source code: https://github.com/paritytech/substrate/blob/master/frame/staking/src/lib.rs#L662