### PR TITLE
Update westend runtime id to match spec version

### DIFF
--- a/scalecodec/type_registry/westend.json
+++ b/scalecodec/type_registry/westend.json
@@ -1,5 +1,5 @@
 {
-  "runtime_id": 900,
+  "runtime_id": 9000,
   "types": {
     "Address": "MultiAddress",
     "LookupSource": "MultiAddress",


### PR DESCRIPTION
Hi, it seems that runtime_id for Westend does not match with actual one
![image](https://user-images.githubusercontent.com/70131744/117825234-d3407000-b277-11eb-8887-6a2752ed4ae1.png)