### PR TITLE
Update field names in FundInfo to match Polkadot definition

### DIFF
--- a/scalecodec/type_registry/default.json
+++ b/scalecodec/type_registry/default.json
@@ -6089,11 +6089,11 @@
           "LastContribution"
         ],
         [
-          "firstSlot",
+          "firstPeriod",
           "LeasePeriod"
         ],
         [
-          "lastSlot",
+          "lastPeriod",
           "LeasePeriod"
         ],
         [


### PR DESCRIPTION
Hi, we noticed that FundInfo has the wrong field names - `firstSlot` and `lastSlot`. It does not really affect correctness, but it was a bit confusing at first to understand the meaning of these fields.

Original ones are `firstPeriod` and `lastPeriod`.  [Polkadot sources link](https://github.com/paritytech/polkadot/blob/master/runtime/common/src/crowdloan.rs#L141)