### PR TITLE
Fix decoding Polymesh events.

### DIFF
--- a/scalecodec/type_registry/polymesh-mainnet.json
+++ b/scalecodec/type_registry/polymesh-mainnet.json
@@ -1,5 +1,8 @@
 {
   "types": {
+    "polymesh_runtime_develop::runtime::Event": "*::Event",
+    "polymesh_runtime_testnet::runtime::Event": "*::Event",
+    "polymesh_runtime_mainnet::runtime::Event": "*::Event",
     "AccountInfo": "AccountInfoWithDualRefCount",
     "Address": "IndicesLookupSource",
     "LookupSource": "IndicesLookupSource",

--- a/scalecodec/type_registry/polymesh-testnet.json
+++ b/scalecodec/type_registry/polymesh-testnet.json
@@ -1,5 +1,8 @@
 {
   "types": {
+    "polymesh_runtime_develop::runtime::Event": "*::Event",
+    "polymesh_runtime_testnet::runtime::Event": "*::Event",
+    "polymesh_runtime_mainnet::runtime::Event": "*::Event",
     "AccountInfo": "AccountInfoWithDualRefCount",
     "Address": "IndicesLookupSource",
     "LookupSource": "IndicesLookupSource",


### PR DESCRIPTION
Polymesh just recently upgraded to v14 metadata and that has caused problems with decoding events for users of scalecodec.

Related issue:
https://github.com/PolymeshAssociation/Polymesh/issues/1334