### PR TITLE
GenericVote available for all pallets

### DIFF
--- a/scalecodec/type_registry/metadata_types.json
+++ b/scalecodec/type_registry/metadata_types.json
@@ -1575,7 +1575,7 @@
     "sp_core::crypto::AccountId32": "GenericAccountId",
     "sp_runtime::multiaddress::MultiAddress": "GenericMultiAddress",
     "sp_runtime::generic::era::Era": "Era",
-    "pallet_democracy::vote::Vote": "GenericVote",
+    "*::vote::Vote": "GenericVote",
     "pallet_identity::types::Data": "Data",
     "frame_support::storage::bounded_vec::BoundedVec": "BoundedVec",
     "frame_support::storage::weak_bounded_vec::WeakBoundedVec": "BoundedVec",


### PR DESCRIPTION
Substrate type `Vote` (https://github.com/paritytech/substrate/blob/70351393fd632317124f35ab8b24ef7134e08864/frame/conviction-voting/src/vote.rs#L32) is a struct stored as an `u8` with a certain bitmask. 

This requires a special decoding class `GenericVote`, which is currently only available for the `democracy` pallet and not other pallets like `conviction-voting`. Here a vote is still being encoded/decoded as a `u8`.