### PR TITLE
ink! 4.2: Contractresult update

### DIFF
--- a/scalecodec/type_registry/__init__.py
+++ b/scalecodec/type_registry/__init__.py
@@ -23,7 +23,7 @@ import requests
 SUPPORTED_TYPE_REGISTRY_PRESETS = ('canvas', 'legacy', 'kusama', 'polkadot', 'rococo', 'core',
                                    'substrate-node-template', 'westend', 'statemint', 'statemine', 'karura',
                                    'moonbeam', 'moonriver', 'moonbase-alpha', 'crust', 'polymesh-mainnet',
-                                   'polymesh-testnet', 'acala', 'test')
+                                   'polymesh-testnet', 'acala', 'test', 'contracts-on-rococo')
 
 ONLINE_BASE_URL = 'https://raw.githubusercontent.com/polkascan/py-scale-codec/v1.0/scalecodec/type_registry/'
 

--- a/scalecodec/type_registry/contracts-on-rococo.json
+++ b/scalecodec/type_registry/contracts-on-rococo.json
@@ -1,0 +1,6 @@
+{
+  "types": {
+    "ContractExecResult": "ContractExecResultTo269"
+  },
+  "versioning": []
+}

--- a/scalecodec/type_registry/core.json
+++ b/scalecodec/type_registry/core.json
@@ -1573,6 +1573,8 @@
       ]
     },
     "Compact<Moment>": "CompactMoment",
+    "primitive_types::H256": "H256",
+    "primitive_types::U256": "U256",
     "sp_core::crypto::AccountId32": "GenericAccountId",
     "sp_runtime::multiaddress::MultiAddress": "GenericMultiAddress",
     "sp_runtime::generic::era::Era": "Era",
@@ -1633,6 +1635,36 @@
         [
           "result",
           "ContractExecResultResult"
+        ]
+      ]
+    },
+    "ContractExecResultTo269": {
+      "type": "struct",
+      "base_class": "GenericContractExecResultV2",
+      "type_mapping": [
+        [
+          "gas_consumed",
+          "Weight"
+        ],
+        [
+          "gas_required",
+          "Weight"
+        ],
+        [
+          "storage_deposit",
+          "StorageDeposit"
+        ],
+        [
+          "debug_message",
+          "Bytes"
+        ],
+        [
+          "result",
+          "ContractExecResultResult"
+        ],
+        [
+          "events",
+          "Option<Vec<frame_system::eventrecord>>"
         ]
       ]
     },


### PR DESCRIPTION
* Added new `ContractExecResultTo269`
* Added preset for "contracts-on-rococo" parachain
* Added override for scale info path "primitive_types::U256"