### PR TITLE
Fix `--no-binary` installation and PEP 561 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ elif environ.get('GITHUB_REF'):
 
     version = environ['GITHUB_REF'].replace('refs/tags/v', '')
 else:
-    raise ValueError('Missing commit tag, can\'t set version')
+    version = '0.0.0'
 
 here = path.abspath(path.dirname(__file__))
 


### PR DESCRIPTION
Fixes installation issues in py-substrate-interface: https://github.com/polkascan/py-substrate-interface/issues/366