### PR TITLE
Missed passing `metadata=self.metadata` in `Option.process`

### DIFF
--- a/scalecodec/types.py
+++ b/scalecodec/types.py
@@ -149,7 +149,7 @@ class Option(ScaleType):
         option_byte = self.get_next_bytes(1)
 
         if self.sub_type and option_byte != b'\x00':
-            self.value_object = self.process_type(self.sub_type)
+            self.value_object = self.process_type(self.sub_type, metadata=self.metadata)
             return self.value_object.value
 
         return None


### PR DESCRIPTION
I'm actually not quite sure how to add a test for this. But it resolves decoding an Extrinsic with the data

```
ScaleBytes("0x85028400d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d01d8a8c7ab390badc106832ccb721d1acea313335db6c0bcd816c160a1c2784e3f41f503d08f321ab66aa3401e941737ebad721ea3db5c7bee784b87f9130fcc8e009c00001b000700c817a80402286bee0700902f50099228010001073b8eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a4800")
```

given this metadata:
[metadata.txt](https://github.com/user-attachments/files/22936194/metadata.txt)
